### PR TITLE
Prevent IRC connection deadlock with proactive keep-alive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
     if utils::is_dev() {
         log_level = log::LevelFilter::Debug;
     } else {
-        log_level = log::LevelFilter::Warn;
+        log_level = log::LevelFilter::Info;
     }
 
     tauri::Builder::default().setup(setup)

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,16 +131,13 @@ fn on_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
     }
 }
 
-#[tokio::main]
-async fn main() {
-    tauri::async_runtime::set(tokio::runtime::Handle::current());
-
+fn main() {
     let log_level: log::LevelFilter;
     if utils::is_dev() {
         log_level = log::LevelFilter::Debug;
     } else {
         log_level = log::LevelFilter::Warn;
-    };
+    }
 
     tauri::Builder::default().setup(setup)
         .plugin(tauri_plugin_log::Builder::default()

--- a/src/twitch/mod.rs
+++ b/src/twitch/mod.rs
@@ -139,7 +139,6 @@ fn handle_ready_event(_app: tauri::AppHandle<tauri::Wry>, event_type: &str, payl
                 log::info!("Twitch IRC client disconnected. Attempting to reconnect...");
                 if let Err(e) = connect_result {
                     log::error!("Failed to connect to Twitch IRC: {:?}", e);
-                    tokio::time::sleep(Duration::from_secs(5)).await;
                 } else if let Ok(client) = connect_result {
                     log::info!("Twitch IRC task cancelled. Parting from channel: {}", channel_name);
                     if let Err(e) = client.send(Command::PART(format!("#{}", channel_name), None)) {

--- a/src/twitch/mod.rs
+++ b/src/twitch/mod.rs
@@ -82,6 +82,8 @@ async fn handle_create_connection(channel_name: &str) -> Result<Client, Box<dyn 
     let config = Config {
         server: Some(String::from("irc.chat.twitch.tv")),
         port: Some(6667),
+        ping_time: Some(30),
+        ping_timeout: Some(5),
         ..Config::default()
     };
 
@@ -97,7 +99,7 @@ async fn handle_create_connection(channel_name: &str) -> Result<Client, Box<dyn 
 
     let mut stream = client.stream()?;
     while let Some(message) = stream.next().await.transpose()? {
-        if let Command::PING(_server1, _server2) = message.command {
+        if let Command::PONG(_server1, _server2) = message.command {
             if let Err(e) = dispatch_event(json!({ "type": "ping" })) {
                 log::error!("Failed to handle Twitch PING event: {:?}", e);
             }

--- a/src/twitch/mod.rs
+++ b/src/twitch/mod.rs
@@ -97,6 +97,8 @@ async fn handle_create_connection(channel_name: &str) -> Result<Client, Box<dyn 
     client.send(Command::USER(nickname.clone(), String::from("8"), nickname.clone()))?;
     client.send(Command::JOIN(format!("#{}", channel_name), None, None))?;
 
+    log::info!("Joined Twitch channel '#{}'.", channel_name);
+
     let mut stream = client.stream()?;
     while let Some(message) = stream.next().await.transpose()? {
         if matches!(message.command, Command::PONG(_, _) | Command::PING(_, _) | Command::Response(Response::RPL_WELCOME, _)) {
@@ -132,11 +134,10 @@ fn handle_ready_event(_app: tauri::AppHandle<tauri::Wry>, event_type: &str, payl
 
                 let connect_result = handle_create_connection(&channel_name).await;
 
-                log::info!("Twitch IRC client disconnected. Attempting to reconnect...");
                 if let Err(e) = connect_result {
-                    log::error!("Failed to connect to Twitch IRC: {:?}", e);
+                    log::error!("Twitch IRC client exited with error: {:?}", e);
                 } else if let Ok(client) = connect_result {
-                    log::info!("Twitch IRC task cancelled. Parting from channel: {}", channel_name);
+                    log::info!("Twitch IRC client exited normally. Try to parting from channel: {}", channel_name);
                     if let Err(e) = client.send(Command::PART(format!("#{}", channel_name), None)) {
                         log::error!("Failed to send PART command: {:?}", e);
                     }
@@ -147,6 +148,7 @@ fn handle_ready_event(_app: tauri::AppHandle<tauri::Wry>, event_type: &str, payl
                     }
                 }
 
+                log::info!("Reconnecting to Twitch IRC in 5 seconds...");
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }
         }));


### PR DESCRIPTION
The IRC client could enter a deadlock on `stream.next().await.transpose()` during a silent network connection loss, which prevented the reconnection logic from triggering.


### Fix

Implemented the irc client's built-in keep-alive mechanism to proactively detect and terminate dead connections.
Configured `ping_time` (30s) and `ping_timeout` (5s) to force a `PingTimeout` error when the server is unresponsive.


### Improvement

- Enhanced log feedback in the re-connection handler to clearly distinguish between disconnections caused by an error versus a normal exit.
- Unified the event dispatching for `PING`, `PONG`, and `RPL_WELCOME` messages into a single if `matches!` block for improved readability.